### PR TITLE
Remove bindings helper

### DIFF
--- a/datadog/build.go
+++ b/datadog/build.go
@@ -59,9 +59,5 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			NewNodeJSAgent(context.Application.Path, context.Buildpack.Path, dep, dc, b.Logger))
 	}
 
-	h, _ := libpak.NewHelperLayer(context.Buildpack, "properties")
-	h.Logger = b.Logger
-	result.Layers = append(result.Layers, h)
-
 	return result, nil
 }

--- a/datadog/build_test.go
+++ b/datadog/build_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/buildpacks/libcnb"
 	. "github.com/onsi/gomega"
-	"github.com/paketo-buildpacks/libpak"
 	"github.com/sclevine/spec"
 
 	"github.com/paketo-buildpacks/datadog/datadog"
@@ -42,10 +41,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		result, err := datadog.Build{}.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(result.Layers).To(HaveLen(2))
+		Expect(result.Layers).To(HaveLen(1))
 		Expect(result.Layers[0].Name()).To(Equal("datadog-agent-java"))
-		Expect(result.Layers[1].Name()).To(Equal("helper"))
-		Expect(result.Layers[1].(libpak.HelperLayerContributor).Names).To(Equal([]string{"properties"}))
 	})
 
 	it("contributes Java agent API >= 0.7", func() {
@@ -67,10 +64,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		result, err := datadog.Build{}.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(result.Layers).To(HaveLen(2))
+		Expect(result.Layers).To(HaveLen(1))
 		Expect(result.Layers[0].Name()).To(Equal("datadog-agent-java"))
-		Expect(result.Layers[1].Name()).To(Equal("helper"))
-		Expect(result.Layers[1].(libpak.HelperLayerContributor).Names).To(Equal([]string{"properties"}))
 	})
 
 	it("contributes NodeJS agent API <= 0.6", func() {
@@ -90,9 +85,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		result, err := datadog.Build{}.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(result.Layers).To(HaveLen(2))
+		Expect(result.Layers).To(HaveLen(1))
 		Expect(result.Layers[0].Name()).To(Equal("datadog-agent-nodejs"))
-		Expect(result.Layers[1].(libpak.HelperLayerContributor).Names).To(Equal([]string{"properties"}))
 	})
 
 	it("contributes NodeJS agent API >= 0.7", func() {
@@ -114,8 +108,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		result, err := datadog.Build{}.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(result.Layers).To(HaveLen(2))
+		Expect(result.Layers).To(HaveLen(1))
 		Expect(result.Layers[0].Name()).To(Equal("datadog-agent-nodejs"))
-		Expect(result.Layers[1].(libpak.HelperLayerContributor).Names).To(Equal([]string{"properties"}))
 	})
 }


### PR DESCRIPTION
## Summary

Remove the bindings helper. This was missed in the previous PR that removed binding support.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
