### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/datadog`
 
-The Paketo Datadog Buildpack is a Cloud Native Buildpack that contributes and configures the Datadog Agent.
+The Paketo Buildpack for Datadog is a Cloud Native Buildpack that contributes and configures the Datadog Agent.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/datadog"
   id = "paketo-buildpacks/datadog"
   keywords = ["java"]
-  name = "Paketo Datadog Buildpack"
+  name = "Paketo Buildpack for Datadog"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Datadog Buildpack' to 'Paketo Buildpack for Datadog'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
