### PR TITLE
Add support for native-image builds

### DIFF
--- a/datadog/build.go
+++ b/datadog/build.go
@@ -44,7 +44,13 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			return libcnb.BuildResult{}, fmt.Errorf("unable to find dependency\n%w", err)
 		}
 
-		result.Layers = append(result.Layers, NewJavaAgent(agentDependency, dc, b.Logger))
+		cr, err := libpak.NewConfigurationResolver(context.Buildpack, nil)
+		if (err != nil) {
+			return libcnb.BuildResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
+		}
+		nativeImage := cr.ResolveBool("BP_NATIVE_IMAGE")
+
+		result.Layers = append(result.Layers, NewJavaAgent(agentDependency, dc, b.Logger, nativeImage))
 	}
 
 	if _, ok, err := pr.Resolve("datadog-nodejs"); err != nil {

--- a/datadog/detect.go
+++ b/datadog/detect.go
@@ -26,6 +26,23 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 		return libcnb.DetectResult{Pass: false}, nil
 	}
 
+	// If both BP_DATADOG_ENABLED and BP_NATIVE_IMAGE are enabled, don't require jvm-application plan and prepare for native-image only
+	if cr.ResolveBool("BP_NATIVE_IMAGE") {
+		return libcnb.DetectResult{
+			Pass: true,
+			Plans: []libcnb.BuildPlan{
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "datadog-java"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "datadog-java"},
+					},
+				},
+			},
+		}, nil
+	}
+
 	return libcnb.DetectResult{
 		Pass: true,
 		Plans: []libcnb.BuildPlan{

--- a/datadog/detect_test.go
+++ b/datadog/detect_test.go
@@ -72,4 +72,33 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			}))
 		})
 	})
+
+	context("BP_DATADOG_ENABLED and BP_NATIVE_IMAGE are both enabled", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BP_DATADOG_ENABLED", "true")).To(Succeed())
+			Expect(os.Setenv("BP_NATIVE_IMAGE", "true")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BP_DATADOG_ENABLED")).To(Succeed())
+			Expect(os.Unsetenv("BP_NATIVE_IMAGE")).To(Succeed())
+		})
+
+		it("passes with native-image plan", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "datadog-java"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{Name: "datadog-java"},
+						},
+					},
+				},
+			}))
+		})
+		
+	})
 }

--- a/datadog/java_agent.go
+++ b/datadog/java_agent.go
@@ -21,14 +21,15 @@ import (
 type JavaAgent struct {
 	LayerContributor libpak.DependencyLayerContributor
 	Logger           bard.Logger
+	NativeImage      bool
 }
 
-func NewJavaAgent(dependency libpak.BuildpackDependency, cache libpak.DependencyCache, logger bard.Logger) JavaAgent {
+func NewJavaAgent(dependency libpak.BuildpackDependency, cache libpak.DependencyCache, logger bard.Logger, nativeImage bool) JavaAgent {
 	contrib, _ := libpak.NewDependencyLayer(dependency, cache, libcnb.LayerTypes{
-		Build: true,
+		Build: nativeImage,
 		Launch: true,
 	})
-	return JavaAgent{LayerContributor: contrib, Logger: logger}
+	return JavaAgent{LayerContributor: contrib, Logger: logger, NativeImage: nativeImage}
 }
 
 func (j JavaAgent) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
@@ -42,7 +43,9 @@ func (j JavaAgent) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			return libcnb.Layer{}, fmt.Errorf("unable to copy artifact to %s\n%w", file, err)
 		}
 
-		layer.BuildEnvironment.Appendf("BP_NATIVE_IMAGE_BUILD_ARGUMENTS", " ", "-J-javaagent:%s", file)
+		if (j.NativeImage) {
+			layer.BuildEnvironment.Appendf("BP_NATIVE_IMAGE_BUILD_ARGUMENTS", " ", "-J-javaagent:%s", file)
+		}
 		layer.LaunchEnvironment.Appendf("JAVA_TOOL_OPTIONS", " ", "-javaagent:%s", file)
 
 		return layer, nil

--- a/datadog/java_agent.go
+++ b/datadog/java_agent.go
@@ -25,6 +25,7 @@ type JavaAgent struct {
 
 func NewJavaAgent(dependency libpak.BuildpackDependency, cache libpak.DependencyCache, logger bard.Logger) JavaAgent {
 	contrib, _ := libpak.NewDependencyLayer(dependency, cache, libcnb.LayerTypes{
+		Build: true,
 		Launch: true,
 	})
 	return JavaAgent{LayerContributor: contrib, Logger: logger}
@@ -41,6 +42,7 @@ func (j JavaAgent) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			return libcnb.Layer{}, fmt.Errorf("unable to copy artifact to %s\n%w", file, err)
 		}
 
+		layer.BuildEnvironment.Appendf("BP_NATIVE_IMAGE_BUILD_ARGUMENTS", " ", "-J-javaagent:%s", file)
 		layer.LaunchEnvironment.Appendf("JAVA_TOOL_OPTIONS", " ", "-javaagent:%s", file)
 
 		return layer, nil

--- a/datadog/java_agent_test.go
+++ b/datadog/java_agent_test.go
@@ -54,7 +54,7 @@ func testJavaAgent(t *testing.T, context spec.G, it spec.S) {
 		}
 		dc := libpak.DependencyCache{CachePath: "testdata"}
 
-		j := datadog.NewJavaAgent(dep, dc, bard.NewLogger(io.Discard))
+		j := datadog.NewJavaAgent(dep, dc, bard.NewLogger(io.Discard), false)
 
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

This PR adds support for using the Datadog tracer with native-image built applications.

Unlike default Java applications, instrumenting a native Java application using GraalVM native-image requires the Java agent to be declared as a native-image parameter at build time.
The PR will check for native builds and update the native-image parameters accordingly.

## Use Cases

It will install the Datadog tracer for Java native applications like Spring Boot.
There is an increasing interest in native applications from users and recent versions of frameworks like Spring, Quarkus, or Micronaut. Hence this support addition.

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).

Fixes #131
Fixes DataDog/dd-trace-java#4508
