### PR TITLE
Changes detection for node to include node_modules

### DIFF
--- a/datadog/detect.go
+++ b/datadog/detect.go
@@ -44,6 +44,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 				},
 				Requires: []libcnb.BuildPlanRequire{
 					{Name: "datadog-nodejs"},
+					{Name: "node_modules"},
 					{Name: "node", Metadata: map[string]interface{}{"build": true}},
 				},
 			},

--- a/datadog/detect_test.go
+++ b/datadog/detect_test.go
@@ -64,6 +64,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 						Requires: []libcnb.BuildPlanRequire{
 							{Name: "datadog-nodejs"},
+							{Name: "node_modules"},
 							{Name: "node", Metadata: map[string]interface{}{"build": true}},
 						},
 					},


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This PR changes the detection criteria for Datadog with Node apps. The `node_modules` dependency is now also required, which should still support Node apps while ensuring the Java buildpack does not inadvertently supply `node` to Datadog.

## Use Cases
Fixes #162 

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
